### PR TITLE
Add `image_force_delete` not work comment

### DIFF
--- a/hashicorp/react/images/ali-react.pkr.hcl
+++ b/hashicorp/react/images/ali-react.pkr.hcl
@@ -27,7 +27,8 @@ packer {
 }
 
 source "alicloud-ecs" "react-app" {
-  region                       = var.ecs_image_region
+  region = var.ecs_image_region
+  // The following two options do not work, require `packer build --force` to remove the image used by the instance
   image_force_delete           = true
   image_force_delete_snapshots = true
   image_name                   = var.ecs_image_name


### PR DESCRIPTION
[//]: # (Copyright 2024 Paion Data)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

Changelog
---------

### Added
add `image_force_delete` not work comment, require `packer build --force` to remove the image used by the instance
### Changed

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [ ] Test
- [ ] Self-review
- [ ] Documentation
