### PR TITLE
Fix Syntax Error in init script

### DIFF
--- a/hashicorp/kong-api-gateway/scripts/ali-kong-tf-init.sh
+++ b/hashicorp/kong-api-gateway/scripts/ali-kong-tf-init.sh
@@ -16,6 +16,6 @@ set -e
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HOME_DIR = ${home_dir}
+HOME_DIR=${home_dir}
 cd $HOME_DIR/docker-kong/compose/
 sudo KONG_DATABASE=postgres docker compose --profile database up

--- a/hashicorp/react/scripts/react-tf-init.sh
+++ b/hashicorp/react/scripts/react-tf-init.sh
@@ -16,7 +16,7 @@ set -e
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HOME_DIR = ${home_dir}
+HOME_DIR=${home_dir}
 cd $HOME_DIR
 nginx -s reload
 systemctl restart nginx


### PR DESCRIPTION
[//]: # (Copyright 2024 Paion Data)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed
Fix Syntax Error in kong and react init script
### Security

Checklist
---------

- [ ] Test
- [ ] Self-review
- [ ] Documentation
